### PR TITLE
[bot] add storage and stop command

### DIFF
--- a/internal/bot/handlers/start.go
+++ b/internal/bot/handlers/start.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -44,6 +45,9 @@ func (h *StartHandler) Register(r *router.Router) error {
 		defer cancel()
 
 		if err := h.storage.Store(ctx, contact.PhoneNumber, c.Chat().ID); err != nil {
+			if errors.Is(err, storage.ErrInvalidPhoneNumber) {
+				return c.Send("Invalid phone number format. Please share your contact again.")
+			}
 			return fmt.Errorf("set phone number: %w", err)
 		}
 

--- a/internal/bot/handlers/stop.go
+++ b/internal/bot/handlers/stop.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/capcom6/phone2tg-proxy/internal/bot/fsm"
+	"github.com/capcom6/phone2tg-proxy/internal/bot/router"
+	"github.com/capcom6/phone2tg-proxy/internal/storage"
+	"go.uber.org/zap"
+	"gopkg.in/telebot.v4"
+)
+
+type StopHandler struct {
+	storage storage.Service
+	logger  *zap.Logger
+}
+
+func NewStopHandler(storage storage.Service, logger *zap.Logger) *StopHandler {
+	return &StopHandler{
+		storage: storage,
+		logger:  logger,
+	}
+}
+
+func (h *StopHandler) Register(r *router.Router) error {
+	r.Handle(fsm.StateEmpty, "/stop", func(c telebot.Context, _ *router.StateService) error {
+		telegramID := c.Chat().ID
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		// Perform atomic deletion
+		if err := h.storage.Delete(ctx, telegramID); err != nil {
+			h.logger.Error("failed to delete association", zap.Int64("telegram_id", telegramID), zap.Error(err))
+			return c.Send("Failed to delete association")
+		}
+
+		// Audit logging
+		h.logger.Info("Association deleted", zap.Int64("telegram_id", telegramID))
+
+		return c.Send("Your association has been deleted")
+	})
+
+	return nil
+}

--- a/internal/bot/module.go
+++ b/internal/bot/module.go
@@ -30,6 +30,7 @@ func Module() fx.Option {
 		),
 		fx.Provide(
 			handlers.NewStartHandler,
+			handlers.NewStopHandler,
 			fx.Private,
 		),
 
@@ -38,6 +39,7 @@ func Module() fx.Option {
 			fsm *fsm.Service,
 			logger *zap.Logger,
 			startHandler *handlers.StartHandler,
+			stopHandler *handlers.StopHandler,
 		) error {
 			bot.Use(middleware.Logger(logger))
 
@@ -46,6 +48,11 @@ func Module() fx.Option {
 			if err := startHandler.Register(rt); err != nil {
 				return fmt.Errorf("register start handler: %w", err)
 			}
+
+			if err := stopHandler.Register(rt); err != nil {
+				return fmt.Errorf("register stop handler: %w", err)
+			}
+
 			return nil
 		}),
 	)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -16,11 +16,10 @@ var (
 	ErrInvalidPhoneNumber = errors.New("invalid phone number")
 )
 
-//nolint:iface // interface is required
 type Service interface {
 	Store(ctx context.Context, phoneNumber string, telegramID int64) error
 	Get(ctx context.Context, phoneNumber string) (int64, error)
-	Delete(ctx context.Context, phoneNumber string) error
+	Delete(ctx context.Context, telegramID int64) error
 }
 
 type service struct {
@@ -81,13 +80,8 @@ func (s *service) Get(ctx context.Context, phoneNumber string) (int64, error) {
 	return id, nil
 }
 
-func (s *service) Delete(ctx context.Context, phoneNumber string) error {
-	hashed, err := s.preparePhoneNumber(phoneNumber)
-	if err != nil {
-		return fmt.Errorf("service: %w", err)
-	}
-
-	if err := s.r.Delete(ctx, hashed); err != nil {
+func (s *service) Delete(ctx context.Context, telegramID int64) error {
+	if err := s.r.DeleteByTelegramID(ctx, telegramID); err != nil {
 		return fmt.Errorf("service: %w", err)
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /stop command so users can delete their phone–Telegram association with clear success/failure messages.

* **Bug Fixes**
  * Sharing an invalid contact now yields: "Invalid phone number format. Please share your contact again."
  * Linking and unlinking are more reliable and faster via atomic two-way mappings and targeted deletion by Telegram ID, improving responsiveness and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->